### PR TITLE
chore(devshell): add haskell-language-server to devShell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,7 @@
           buildInputs = with pkgs; [
             # Core build tools
             ghc
+            haskell-language-server
           ];
 
           shellHook = ''

--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,7 @@
             echo -e "System: ${system}"
             echo -e "Available tools:"
             echo -e "  - ghc: $(which ghc 2>/dev/null || echo 'not found')"
-            echo -e "\n\n\033[0m"
+            echo -e "\n\033[0m"
           '';
         };
       }


### PR DESCRIPTION
Adds Haskell Language Server to devShell and tidies shellHook output. Improves developer ergonomics without affecting runtime.